### PR TITLE
docs: [MAD-16766] add AGENTS.md and contributor docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,53 @@
+<!-- PR template -->
+**Ticket:** <!-- Hyperlink the issue, e.g. [PROJ-123](https://liquidweb.atlassian.net/browse/PROJ-123)
+(Jira) or [TEAM-123](https://linear.app/nexcess/issue/TEAM-123/slug) (Linear) — required, or
+state why there isn't one -->
+
+## Why
+
+<!-- What problem does this solve, or what requirement does it fulfill? One sentence is usually
+enough if there's a ticket — it should contain the details. -->
+
+## What
+
+<!-- What changed? Bullet points of the approach taken. -->
+
+### Blast radius
+
+<!-- e.g. backend-only / infra / cross-service / dependency change -->
+
+### Deviations from spec
+
+<!-- Bullet points: what, if anything, changed between the ticket's description and the final
+implementation, and why. Delete this section if there's no spec to deviate from. -->
+
+## Reading guide
+
+<!-- Optional for a small change. For anything touching more than one file, map it for reviewers
+before they read the diff. -->
+
+| File | What to look at | Why |
+|---|---|---|
+| `` | … | … |
+
+## Test plan
+
+**Automated tests added/updated:**
+- [ ] …
+
+**Manual verification steps:**
+1. …
+
+## Deploy notes
+
+<!-- Delete this section if not needed. -->
+
+**Key/secret changes:** <!-- new secrets to provision, keys to issue, or config to update? -->
+**Rollout order:** <!-- any sequencing required (e.g. migrate before deploying)? -->
+**Rollback:** <!-- how to revert if this causes a problem in production? -->
+
+## Checklist
+
+- [ ] Ran `tests/test.sh` (see [AGENTS.md](../AGENTS.md#commands)) against the relevant distro/playbook combination
+- [ ] Docs updated (`README.md`/`AGENTS.md`) if this changes how the project is built, run, or used
+- [ ] No secrets, tokens, or real customer/financial data included

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,89 @@
+# ansible-role-mysql
+
+Installs and configures MySQL or MariaDB server on RHEL/CentOS, Debian/Ubuntu, or Arch Linux hosts.
+
+## Architecture in a paragraph
+
+Playbooks that need a database server pull in this role to get one installed and configured the
+same way regardless of target distro. It's a standalone Ansible role with no role dependencies
+(`meta/main.yml`): `tasks/main.yml` first branches on `ansible_os_family` to run one of
+`setup-RedHat.yml`, `setup-Debian.yml`, or `setup-Archlinux.yml`, each of which installs the
+right packages using the OS-specific names and paths defined in `vars/<OSFamily>.yml` (package
+list, daemon name, config file/socket/PID paths, log locations). Once installed, the OS-agnostic
+tasks take over: `configure.yml` renders `templates/my.cnf.j2` from `defaults/main.yml`
+variables, `secure-installation.yml` sets the root/user passwords and strips anonymous users and
+the test database, `databases.yml` and `users.yml` provision `mysql_databases`/`mysql_users`, and
+`replication.yml` wires up master/slave replication when `mysql_replication_role` is set. Every
+behavior a consuming playbook can control is a `defaults/main.yml` variable — there's no other
+configuration surface.
+
+## File map
+
+```
+defaults/
+  main.yml               # every consumer-facing variable, with inline comments
+handlers/
+  main.yml                # restarts {{ mysql_daemon }} (name varies by OS/vars file)
+meta/
+  main.yml                # Galaxy metadata; dependencies: []
+tasks/
+  main.yml                 # entry point: OS dispatch, then the shared configure/secure/db/user/replication chain
+  variables.yml             # include_vars for the matching vars/<OSFamily>.yml
+  setup-RedHat.yml          # RHEL/CentOS package install
+  setup-Debian.yml          # Debian/Ubuntu package install (stops mysql + clears innodb logs after first install)
+  setup-Archlinux.yml       # Arch package install
+  configure.yml             # renders templates/my.cnf.j2
+  secure-installation.yml   # root/user password, anonymous users, test db removal
+  databases.yml             # mysql_databases -> mysql_db module
+  users.yml                 # mysql_users -> mysql_user module
+  replication.yml           # master/slave replication setup
+templates/
+  my.cnf.j2                 # global my.cnf
+  root-my.cnf.j2             # ~/.my.cnf for mysql_root_username
+  user-my.cnf.j2              # ~/.my.cnf for mysql_user_name (when different from root)
+vars/
+  Archlinux.yml, Debian.yml, RedHat-6.yml, RedHat-7.yml   # per-OS package names, paths, daemon name
+tests/
+  test.yml                  # generic test playbook (role_under_test)
+  centos-7-test.yml         # CentOS 7 variant (overrides to MariaDB package names/paths)
+  initctl_faker              # fake initctl binary, needed on Ubuntu 14.04 containers
+  README.md                   # manual test-run instructions
+.travis.yml                # CI matrix; test shim is fetched at run time from a gist on geerlingguy's account (see Conventions)
+```
+
+## Commands
+
+Test (requires Docker; the runner script is gitignored and fetched at run time, matching
+`.travis.yml`):
+
+```bash
+wget -O tests/test.sh https://gist.githubusercontent.com/geerlingguy/73ef1e5ee45d8694570f334be385e181/raw/
+chmod +x tests/test.sh
+distro=centos7 playbook=centos-7-test.yml ./tests/test.sh
+# or: distro=[centos6|debian8|ubuntu1604|ubuntu1404] playbook=test.yml ./tests/test.sh
+```
+
+Set `cleanup=false container_id=$(date +%s)` first if you want the container left running for
+inspection after the playbook runs.
+
+No lint config (`.ansible-lint`, `.yamllint`) exists in this repo.
+
+## Conventions
+
+- `README.md` states the license as `MIT / BSD`; `meta/main.yml` says `"license (BSD, MIT)"` (an
+  unedited Galaxy scaffold placeholder), while the actual `LICENSE` file is MIT-only. Confirm the
+  real license before relying on any of the three.
+- All per-OS values (package names, daemon name, config/socket/PID paths, log locations) live in
+  `vars/<OSFamily>.yml`, never hardcoded in tasks — add a new OS by adding a `vars/` file and a
+  `setup-<OSFamily>.yml`, not by branching inside the shared tasks.
+- `mysql_root_password_update` / `mysql_user_password_update` gate password changes so the role
+  stays idempotent — a password is only reset on first install or when the flag is explicitly set.
+  Don't remove that guard when touching `secure-installation.yml`.
+- `.travis.yml`'s test script downloads its test shim (`tests/test.sh`, gitignored) from a gist
+  hosted on geerlingguy's personal GitHub account rather than a file committed to this repo —
+  Travis runs here depend on that gist staying available.
+
+## See also
+
+- [README.md](README.md) — install and usage
+- [CONTRIBUTING.md](CONTRIBUTING.md) — PR process

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing
+
+Installs and configures MySQL or MariaDB server on RHEL/CentOS, Debian/Ubuntu, or Arch Linux servers.
+
+## Development setup
+
+See [AGENTS.md](AGENTS.md#commands) for build/test/lint commands — not repeated here.
+
+## Opening a PR
+
+Use this repo's PR template — link the ticket (Jira/Linear/an issue) and describe how the change was verified.
+
+## Before you open a PR
+
+- [ ] Tests pass locally (`tests/test.sh` against the relevant distro/playbook combination)
+- [ ] Lint/static analysis passes, if the repo has one configured
+- [ ] Docs (`README.md`/`AGENTS.md`) updated if this changes how the role is built, run, or used

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Ansible Role: MySQL
 
-[![Build Status](https://travis-ci.org/geerlingguy/ansible-role-mysql.svg?branch=master)](https://travis-ci.org/geerlingguy/ansible-role-mysql)
+Installs and configures MySQL or MariaDB server on RHEL/CentOS, Debian/Ubuntu, or Arch Linux
+servers.
 
-Installs and configures MySQL or MariaDB server on RHEL/CentOS or Debian/Ubuntu servers.
+See [AGENTS.md](AGENTS.md) for how the role is structured and how to run its tests.
 
 ## Requirements
 
@@ -43,7 +44,7 @@ Whether MySQL should be enabled on startup.
 
     mysql_config_file: *default value depends on OS*
     mysql_config_include_dir: *default value depends on OS*
-    
+
 The main my.cnf configuration file and include directory.
 
     overwrite_global_mycnf: yes
@@ -133,7 +134,7 @@ If you want to install MySQL from the official repository instead of installing 
         name: http://repo.mysql.com/mysql-community-release-el7-5.noarch.rpm
         state: present
       when: ansible_os_family == "RedHat"
-  
+
     - name: Override variables for MySQL (RedHat).
       set_fact:
         mysql_daemon: mysqld
@@ -184,10 +185,15 @@ None.
         password: similarly-secure-password
         priv: "example_db.*:ALL"
 
+## Testing and contributing
+
+See [AGENTS.md](AGENTS.md#commands) for how to exercise this role against Docker containers, and
+[CONTRIBUTING.md](CONTRIBUTING.md) before opening a PR.
+
 ## License
 
 MIT / BSD
 
 ## Author Information
 
-This role was created in 2014 by [Jeff Geerling](https://www.jeffgeerling.com/), author of [Ansible for DevOps](https://www.ansiblefordevops.com/).
+This role was created in 2014 by [Jeff Geerling](https://www.jeffgeerling.com/), author of [Ansible for DevOps](https://www.ansiblefordevops.com/). This repository is a fork maintained for internal use.


### PR DESCRIPTION
**Ticket:** [MAD-16766](https://liquidweb.atlassian.net/browse/MAD-16766)

## Why

This role had no `AGENTS.md`/`CLAUDE.md` for agent-assisted work and no `CONTRIBUTING.md` or PR
template. Generated via the org's `generating-docs` skill so this repo matches the shape other
NocWorx repos already use.

## What

- Added `AGENTS.md` (architecture paragraph, annotated file map, commands, conventions).
- Added `CLAUDE.md` as a symlink to `AGENTS.md`.
- Updated `README.md` to cross-link `AGENTS.md`/`CONTRIBUTING.md` instead of duplicating content.
- Added `CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md`.

Every claim in the drafted docs was checked against this repo's actual source by an independent
reviewer (fresh context, no drafting rationale) before this PR was opened.

### Fixed during review

- Fixed a false claim that `.travis.yml`'s badge/webhook reference the upstream repo — it doesn't; the real stale reference was in the original README, which the draft already removed.

### Blast radius

Docs only. No task, template, handler, or default changed.

## Test plan

**Automated tests added/updated:** N/A (docs-only)

**Manual verification steps:**
1. Confirm `CLAUDE.md` resolves as a symlink to `AGENTS.md`: `readlink CLAUDE.md`
2. Skim `AGENTS.md` and `README.md` for accuracy against this role's actual `tasks/`/`defaults/`.

**Flagged, not fixed in this PR (needs a human call or separate follow-up):**

- README states license as "MIT / BSD"; `meta/main.yml` says `"license (BSD, MIT)"` (looks like an unedited Galaxy placeholder) while `LICENSE` is MIT-only. Documented, not resolved.

## Checklist

- [x] Docs updated (this PR is docs-only)
- [x] No secrets, tokens, or real customer/financial data included

issue: MAD-16766


[MAD-16766]: https://liquidweb.atlassian.net/browse/MAD-16766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ